### PR TITLE
[DO NOT MERGE] 認可処理用の型を実装した

### DIFF
--- a/crates/sos24-use-case/src/dto.rs
+++ b/crates/sos24-use-case/src/dto.rs
@@ -1,3 +1,6 @@
+use self::authorization::PermissionGate;
+
+pub mod authorization;
 pub mod news;
 pub mod user;
 
@@ -5,6 +8,12 @@ pub trait ToEntity {
     type Entity;
     type Error: std::error::Error;
     fn into_entity(self) -> Result<Self::Entity, Self::Error>;
+}
+
+pub trait ToEntityWithPermissionGate {
+    type Entity;
+    type Error: std::error::Error;
+    fn into_entity(self) -> Result<PermissionGate<Self::Entity>, Self::Error>;
 }
 
 pub trait FromEntity {

--- a/crates/sos24-use-case/src/dto/authorization.rs
+++ b/crates/sos24-use-case/src/dto/authorization.rs
@@ -1,0 +1,20 @@
+use sos24_domain::entity::{actor::Actor, permission::PermissionDeniedError};
+
+pub mod news;
+pub mod user;
+
+pub struct PermissionGate<T>(T);
+
+impl<T> PermissionGate<T> {
+    pub fn new(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+pub trait PermissionGateExt<A, T> {
+    fn new(inner: T) -> Self;
+    fn for_create(self, actor: &Actor) -> Result<T, PermissionDeniedError>;
+    fn for_read(self, actor: &Actor) -> Result<T, PermissionDeniedError>;
+    fn for_update(self, actor: &Actor) -> Result<T, PermissionDeniedError>;
+    fn for_delete(self, actor: &Actor) -> Result<T, PermissionDeniedError>;
+}

--- a/crates/sos24-use-case/src/dto/authorization/news.rs
+++ b/crates/sos24-use-case/src/dto/authorization/news.rs
@@ -1,0 +1,43 @@
+use sos24_domain::{
+    ensure,
+    entity::{
+        actor::Actor,
+        news::{News, NewsId},
+        permission::{PermissionDeniedError, Permissions},
+    },
+};
+
+use crate::dto::news::NewsDto;
+
+use super::{PermissionGate, PermissionGateExt};
+
+trait NewsTrait {}
+impl NewsTrait for NewsId {}
+impl NewsTrait for News {}
+impl NewsTrait for NewsDto {}
+
+impl<T: NewsTrait> PermissionGateExt<News, T> for PermissionGate<T> {
+    fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    fn for_create(self, actor: &Actor) -> Result<T, PermissionDeniedError> {
+        ensure!(actor.has_permission(Permissions::CREATE_NEWS));
+        Ok(self.0)
+    }
+
+    fn for_read(self, actor: &Actor) -> Result<T, PermissionDeniedError> {
+        ensure!(actor.has_permission(Permissions::READ_NEWS_ALL));
+        Ok(self.0)
+    }
+
+    fn for_update(self, actor: &Actor) -> Result<T, PermissionDeniedError> {
+        ensure!(actor.has_permission(Permissions::UPDATE_NEWS_ALL));
+        Ok(self.0)
+    }
+
+    fn for_delete(self, actor: &Actor) -> Result<T, PermissionDeniedError> {
+        ensure!(actor.has_permission(Permissions::DELETE_NEWS_ALL));
+        Ok(self.0)
+    }
+}

--- a/crates/sos24-use-case/src/dto/authorization/user.rs
+++ b/crates/sos24-use-case/src/dto/authorization/user.rs
@@ -1,0 +1,42 @@
+use sos24_domain::{
+    ensure,
+    entity::{
+        actor::Actor,
+        permission::{PermissionDeniedError, Permissions},
+        user::{User, UserId},
+    },
+};
+
+use crate::dto::user::UserDto;
+
+use super::{PermissionGate, PermissionGateExt};
+
+trait UserTrait {}
+impl UserTrait for UserId {}
+impl UserTrait for User {}
+impl UserTrait for UserDto {}
+
+impl<T: UserTrait> PermissionGateExt<User, T> for PermissionGate<T> {
+    fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    fn for_create(self, _: &Actor) -> Result<T, PermissionDeniedError> {
+        panic!();
+    }
+
+    fn for_read(self, actor: &Actor) -> Result<T, PermissionDeniedError> {
+        ensure!(actor.has_permission(Permissions::READ_USER_ALL));
+        Ok(self.0)
+    }
+
+    fn for_update(self, actor: &Actor) -> Result<T, PermissionDeniedError> {
+        ensure!(actor.has_permission(Permissions::UPDATE_USER_ALL));
+        Ok(self.0)
+    }
+
+    fn for_delete(self, actor: &Actor) -> Result<T, PermissionDeniedError> {
+        ensure!(actor.has_permission(Permissions::DELETE_USER_ALL));
+        Ok(self.0)
+    }
+}


### PR DESCRIPTION
close #24

インターフェイスとして使いやすいのか疑問に思うところがあるのと、既存の実装と挙動の差異(※)があるため一旦保留。
(※) 権限がないエンティティに対しての操作はNOT FOUNDを返すべきであるが、この実装ではFORBIDDENを返すようになっている。

あと認可ってdomainとuse-caseのどちらで行うべき？僕はdomainだと思ってる