### PR TITLE
申請一覧のAPIでanswered_atとanswer_idを返すようにした

### DIFF
--- a/crates/sos24-presentation/src/error/convert_error.rs
+++ b/crates/sos24-presentation/src/error/convert_error.rs
@@ -43,6 +43,11 @@ impl From<FormUseCaseError> for AppError {
             FormUseCaseError::NotFound(_) => {
                 AppError::new(StatusCode::NOT_FOUND, "form/not-found".to_string(), message)
             }
+            FormUseCaseError::ProjectNotFound(_) => AppError::new(
+                StatusCode::NOT_FOUND,
+                "form/project-not-found".to_string(),
+                message,
+            ),
             FormUseCaseError::HasAnswers => AppError::new(
                 StatusCode::BAD_REQUEST,
                 "form/has-answers".to_string(),
@@ -60,6 +65,7 @@ impl From<FormUseCaseError> for AppError {
             FormUseCaseError::FormError(e) => e.into(),
             FormUseCaseError::FormAnswerRepositoryError(e) => e.into(),
             FormUseCaseError::FileIdError(e) => e.into(),
+            FormUseCaseError::ProjectRepositoryError(e) => e.into(),
         }
     }
 }

--- a/crates/sos24-presentation/src/model/form.rs
+++ b/crates/sos24-presentation/src/model/form.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use sos24_use_case::dto::form::{
-    CreateFormDto, FormDto, FormItemDto, FormItemKindDto, NewFormItemDto, UpdateFormDto,
-};
+use sos24_use_case::dto::form::{CreateFormDto, FormDto, FormItemDto, FormItemKindDto, FormWithAnswerDto, NewFormItemDto, UpdateFormDto};
 use sos24_use_case::dto::project::{ProjectAttributeDto, ProjectCategoryDto};
 
 use crate::model::project::{ProjectAttribute, ProjectCategory};
@@ -141,6 +139,56 @@ impl From<FormDto> for Form {
             deleted_at: form.deleted_at.map(|it| it.to_rfc3339()),
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FormWithAnswer {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub starts_at: String,
+    pub ends_at: String,
+    pub categories: Vec<ProjectCategory>,
+    pub attributes: Vec<ProjectAttribute>,
+    pub items: Vec<FormItem>,
+    pub answer_id: Option<String>,
+    pub answered_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+impl From<FormWithAnswerDto> for FormWithAnswer {
+    fn from(form: FormWithAnswerDto) -> Self {
+        FormWithAnswer {
+            id: form.id.to_string(),
+            title: form.title,
+            description: form.description,
+            starts_at: form.starts_at.to_rfc3339(),
+            ends_at: form.ends_at.to_rfc3339(),
+            categories: form
+                .categories
+                .into_iter()
+                .map(ProjectCategory::from)
+                .collect(),
+            attributes: form
+                .attributes
+                .into_iter()
+                .map(ProjectAttribute::from)
+                .collect(),
+            items: form.items.into_iter().map(FormItem::from).collect(),
+            answer_id: form.answer_id.map(|it| it.to_string()),
+            answered_at: form.answered_at.map(|it| it.to_rfc3339()),
+            created_at: form.created_at.to_rfc3339(),
+            updated_at: form.updated_at.to_rfc3339(),
+            deleted_at: form.deleted_at.map(|it| it.to_rfc3339()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FormQuery {
+    pub project_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/sos24-use-case/src/interactor/form.rs
+++ b/crates/sos24-use-case/src/interactor/form.rs
@@ -12,6 +12,8 @@ use sos24_domain::{
     repository::{form::FormRepositoryError, form_answer::FormAnswerRepositoryError, Repositories},
 };
 use sos24_domain::entity::file_data::FileIdError;
+use sos24_domain::entity::project::ProjectId;
+use sos24_domain::repository::project::ProjectRepositoryError;
 
 use crate::context::ContextError;
 use crate::interactor::project::ProjectUseCaseError;
@@ -19,6 +21,7 @@ use crate::interactor::project::ProjectUseCaseError;
 pub mod create;
 pub mod delete_by_id;
 pub mod find_by_id;
+pub mod find_by_project_id;
 pub mod list;
 pub mod update;
 
@@ -26,9 +29,13 @@ pub mod update;
 pub enum FormUseCaseError {
     #[error("Form not found: {0:?}")]
     NotFound(FormId),
+    #[error("Project not found: {0:?}")]
+    ProjectNotFound(ProjectId),
     #[error("Form has answers")]
     HasAnswers,
 
+    #[error(transparent)]
+    ProjectRepositoryError(#[from] ProjectRepositoryError),
     #[error(transparent)]
     FormError(#[from] FormError),
     #[error(transparent)]

--- a/crates/sos24-use-case/src/interactor/form/find_by_project_id.rs
+++ b/crates/sos24-use-case/src/interactor/form/find_by_project_id.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use sos24_domain::{
+    ensure,
+    entity::permission::Permissions,
+    repository::{form::FormRepository, Repositories},
+};
+use sos24_domain::entity::project::ProjectId;
+use sos24_domain::repository::form_answer::FormAnswerRepository;
+use sos24_domain::repository::project::ProjectRepository;
+
+use crate::{context::Context, dto::FromEntity};
+use crate::dto::form::FormWithAnswerDto;
+
+use super::{FormUseCase, FormUseCaseError};
+
+impl<R: Repositories> FormUseCase<R> {
+    pub async fn find_by_project_id(
+        &self,
+        ctx: &Context,
+        project_id: String,
+    ) -> Result<Vec<FormWithAnswerDto>, FormUseCaseError> {
+        let actor = ctx.actor(Arc::clone(&self.repositories)).await?;
+        ensure!(actor.has_permission(Permissions::READ_FORM_ALL));
+
+        let project_id = ProjectId::try_from(project_id)?;
+        let project = self
+            .repositories
+            .project_repository()
+            .find_by_id(project_id.clone())
+            .await?
+            .ok_or(FormUseCaseError::ProjectNotFound(project_id.clone()))?;
+        ensure!(project.value.is_visible_to(&actor));
+
+        let forms = self.repositories.form_repository().list().await?;
+
+        // FIXME : N+1
+        let mut form_list = vec![];
+        for form in forms {
+            let form_id = form.value.id().clone();
+            let form_answer = self
+                .repositories
+                .form_answer_repository()
+                .find_by_project_id_and_form_id(project_id.clone(), form_id)
+                .await?;
+            form_list.push(FormWithAnswerDto::from_entity((form, form_answer)));
+        }
+        Ok(form_list)
+    }
+}
+
+#[cfg(test)]
+mod tests {}


### PR DESCRIPTION
close #99

そもそもクエリとしてproject_idを受け付けていなかったのでスキーマに準拠するように
企画区分属性に基づくフィルタリングはしていないのでこれをserver/clientのどちらでやるかを相談するべき