### PR TITLE
CDのトリガーを変更した

### DIFF
--- a/.github/workflows/cd-beta.yaml
+++ b/.github/workflows/cd-beta.yaml
@@ -23,7 +23,8 @@ on:
 
 jobs:
   push-image:
-    if: github.event.pull_request.merged == true || github.event.inputs.deploy-only == 'false'
+    # if: github.event.pull_request.merged == true || github.event.inputs.deploy-only == 'false'
+    if: github.event.inputs.deploy-only == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,9 +75,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: push-image
-    if: |
-      (github.event.pull_request.merged == true && always() && !failure() && !cancelled()) ||
-      (github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled())
+    # if: |
+    #   (github.event.pull_request.merged == true && always() && !failure() && !cancelled()) ||
+    #   (github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled())
+    if: github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled()
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -2,11 +2,14 @@ name: CD(staging)
 run-name: CD(staging) - ${{ github.event_name }}
 
 on:
-  pull_request:
+  push:
     branches:
-      - develop
-    types:
-      - closed
+      - main
+  # pull_request:
+  #   branches:
+  #     - main
+  #   types:
+  #     - closed
 
   workflow_dispatch:
     inputs:
@@ -23,7 +26,8 @@ on:
 
 jobs:
   push-image:
-    if: github.event.pull_request.merged == true || github.event.inputs.deploy-only == 'false'
+    # if: github.event.pull_request.merged == true || github.event.inputs.deploy-only == 'false'
+    if: github.event_name == 'push' || github.event.inputs.deploy-only == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -77,8 +81,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: push-image
+    # if: |
+    #   (github.event.pull_request.merged == true && always() && !failure() && !cancelled()) ||
+    #   (github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled())
     if: |
-      (github.event.pull_request.merged == true && always() && !failure() && !cancelled()) ||
+      (github.event_name == 'push' && always() && !failure() && !cancelled()) ||
       (github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled())
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,11 +2,11 @@ name: CD(prodution)
 run-name: CD(prodution) - ${{ github.event_name }}
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+  # pull_request:
+  #   branches:
+  #     - main
+  #   types:
+  #     - closed
   workflow_dispatch:
     inputs:
       push-image-only:
@@ -22,7 +22,8 @@ on:
 
 jobs:
   push-image:
-    if: github.event.pull_request.merged == true || github.event.inputs.deploy-only == 'false'
+    # if: github.event.pull_request.merged == true || github.event.inputs.deploy-only == 'false'
+    if: github.event.inputs.deploy-only == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -73,9 +74,10 @@ jobs:
   deploy:
     needs: push-image
     runs-on: ubuntu-latest
-    if: |
-      (github.event.pull_request.merged == true && always() && !failure() && !cancelled()) ||
-      (github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled())
+    # if: |
+    #   (github.event.pull_request.merged == true && always() && !failure() && !cancelled()) ||
+    #   (github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled())
+    if: github.event.inputs.push-image-only == 'false' && always() && !failure() && !cancelled()
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
developを廃止し、mainを軸に開発することを想定
- prod: mainでのworkflow_dispatchの呼び出しをトリガーとするデプロイ
- beta: 上に同じ
- stg: mainでのpush, pull requestのmergeをトリガーとする自動デプロイ
  - 機能の実装、修正は、mainからブランチを切ってmainへPRを出すこと